### PR TITLE
fix: fix h1 line-height for md:screen

### DIFF
--- a/components/Title.tsx
+++ b/components/Title.tsx
@@ -1,7 +1,7 @@
 export default function Title() {
   return (
     <div className="mb-16 flex flex-col items-center">
-      <h1 className="uppercase mb-2 leading-relaxed text-4xl md:text-6xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-purple-500">
+      <h1 className="uppercase mb-2 leading-relaxed md:leading-relaxed text-4xl md:text-6xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-purple-500">
         🕸 Preview
       </h1>
       <p className="mb-8 text-xl md:text-2xl text-gray-400 font-thin font-sans text-center">


### PR DESCRIPTION
Hello 🖐, 

I found a bug on md:screen concerning the H1.

The line-height defined by the leading-relaxed class was overwrited by the default value of line height from the text-6xl class.

![heading_bug](https://user-images.githubusercontent.com/53506859/148209174-c17a4747-8bf7-4da4-a472-a8494bf15f01.jpg)

Here result after fix ⬇

![heading_fix](https://user-images.githubusercontent.com/53506859/148209177-d96a9d78-3e90-4950-9ad1-cc3a53fe2d5c.jpg)

